### PR TITLE
Allow custom policies and a way to hide tool altogether.

### DIFF
--- a/src/NovaPermissionTool.php
+++ b/src/NovaPermissionTool.php
@@ -2,6 +2,7 @@
 
 namespace Vyuldashev\NovaPermission;
 
+use Auth;
 use Laravel\Nova\Nova;
 use Laravel\Nova\Tool;
 
@@ -23,10 +24,16 @@ class NovaPermissionTool extends Tool
     /**
      * Build the view that renders the navigation links for the tool.
      *
-     * @return \Illuminate\View\View
+     * @return \Illuminate\View\View|string
      */
     public function renderNavigation()
     {
+        if ($tool = config('permission.nova.tool_role')) {
+            return Auth::user()->hasRole($tool)
+                ? view('nova-permission-tool::navigation')
+                : '';
+        }
+
         return view('nova-permission-tool::navigation');
     }
 }

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -27,8 +27,10 @@ class ToolServiceProvider extends ServiceProvider
             $this->routes();
         });
 
-        Gate::policy(config('permission.models.permission'), PermissionPolicy::class);
-        Gate::policy(config('permission.models.role'), RolePolicy::class);
+        Gate::policy(config('permission.models.permission'),
+            config('permission.nova.policies.permission', PermissionPolicy::class));
+        Gate::policy(config('permission.models.role'),
+            config('permission.nova.policies.role', RolePolicy::class));
 
         Nova::serving(function (ServingNova $event) {
             //


### PR DESCRIPTION
If your organization has more than one user using Nova, then you'll need to restrict access to roles and permissions tool you made.

This can be accomplished by allowing a custom policy to be specified.

From what I can see, Nova doesn't provide a policy driven path to hiding tools entirely from navigation like resources do with `viewAny`. Solution, `return ''` in `renderNavigation`. Not beautiful but perfectly reasonable.