### PR TITLE
Set singular label on relations

### DIFF
--- a/src/Permission.php
+++ b/src/Permission.php
@@ -91,8 +91,12 @@ class Permission extends Resource
             DateTime::make(__('nova-permission-tool::permissions.created_at'), 'created_at')->exceptOnForms(),
             DateTime::make(__('nova-permission-tool::permissions.updated_at'), 'updated_at')->exceptOnForms(),
 
-            BelongsToMany::make(__('nova-permission-tool::resources.Roles'), 'roles', Role::class)->searchable(),
-            MorphToMany::make($userResource::label(), 'users', $userResource)->searchable(),
+            BelongsToMany::make(Role::label(), 'roles', Role::class)
+                ->searchable()
+                ->singularLabel(Role::singularLabel()),
+            MorphToMany::make($userResource::label(), 'users', $userResource)
+                ->searchable()
+                ->singularLabel($userResource::singularLabel()),
         ];
     }
 

--- a/src/Role.php
+++ b/src/Role.php
@@ -85,8 +85,12 @@ class Role extends Resource
             DateTime::make(__('nova-permission-tool::roles.created_at'), 'created_at')->exceptOnForms(),
             DateTime::make(__('nova-permission-tool::roles.updated_at'), 'updated_at')->exceptOnForms(),
 
-            BelongsToMany::make(__('nova-permission-tool::resources.Permissions'), 'permissions', Permission::class)->searchable(),
-            MorphToMany::make($userResource::label(), 'users', $userResource)->searchable(),
+            BelongsToMany::make(Permission::label(), 'permissions', Permission::class)
+                ->searchable()
+                ->singularLabel(Permission::singularLabel()),
+            MorphToMany::make($userResource::label(), 'users', $userResource)
+                ->searchable()
+                ->singularLabel($userResource::singularLabel()),
         ];
     }
 


### PR DESCRIPTION
In Nova the singular label for a relation field is generated from the name. In some languages where the plural version ends with "ies", for example "Permissies" in Dutch, the singular version is transformed by `Str::singular` to "Permissy". In order to fix this problem we need to set the singular label on the relation field.