### PR TITLE
Remove view publishing and loading.

### DIFF
--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -16,16 +16,11 @@ class ToolServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'nova-permission-tool');
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'nova-permission-tool');
 
         $this->publishes([
             __DIR__.'/../resources/lang' => resource_path('lang/vendor/nova-permission-tool'),
         ], 'nova-permission-tool-lang');
-
-        $this->publishes([
-            __DIR__.'/../resources/views' => resource_path('views/vendor/nova-permission-tool'),
-        ], 'nova-permission-tool-views');
 
         $this->app->booted(function () {
             $this->routes();


### PR DESCRIPTION
Due to the package not having views anymore, running view:cache causes the command to fail due to the missing folder.