### PR TITLE
Fixed Missing translations for permissions and roles labels

### DIFF
--- a/resources/lang/en/permissions.php
+++ b/resources/lang/en/permissions.php
@@ -6,4 +6,5 @@ return [
     'guard_name' => 'Guard Name',
     'created_at' => 'Created at',
     'updated_at' => 'Updated at',
+    'roles' => 'Roles'
 ];

--- a/resources/lang/en/permissions.php
+++ b/resources/lang/en/permissions.php
@@ -6,5 +6,5 @@ return [
     'guard_name' => 'Guard Name',
     'created_at' => 'Created at',
     'updated_at' => 'Updated at',
-    'roles' => 'Roles'
+    'roles' => 'Roles',
 ];

--- a/resources/lang/en/roles.php
+++ b/resources/lang/en/roles.php
@@ -5,4 +5,5 @@ return [
     'guard_name' => 'Guard Name',
     'created_at' => 'Created at',
     'updated_at' => 'Updated at',
+    'permissions' => 'Permissions',
 ];

--- a/resources/lang/es/permissions.php
+++ b/resources/lang/es/permissions.php
@@ -6,4 +6,5 @@ return [
     'guard_name' => 'Nombre de guardia',
     'created_at' => 'Fecha de creación',
     'updated_at' => 'Fecha de actualización',
+    'roles' => 'Roles'
 ];

--- a/resources/lang/es/permissions.php
+++ b/resources/lang/es/permissions.php
@@ -6,5 +6,5 @@ return [
     'guard_name' => 'Nombre de guardia',
     'created_at' => 'Fecha de creación',
     'updated_at' => 'Fecha de actualización',
-    'roles' => 'Roles'
+    'roles' => 'Roles',
 ];

--- a/resources/lang/es/roles.php
+++ b/resources/lang/es/roles.php
@@ -5,4 +5,5 @@ return [
     'guard_name' => 'Nombre de guardia',
     'created_at' => 'Fecha de creación',
     'updated_at' => 'Fecha de actualización',
+    'permissions' => 'Permisos',
 ];

--- a/src/Permission.php
+++ b/src/Permission.php
@@ -110,7 +110,7 @@ class Permission extends Resource
             DateTime::make(__('nova-permission-tool::permissions.created_at'), 'created_at')->exceptOnForms(),
             DateTime::make(__('nova-permission-tool::permissions.updated_at'), 'updated_at')->exceptOnForms(),
 
-            RoleBooleanGroup::make(__('nova-permission-tool::permissions.roles'),'roles'),
+            RoleBooleanGroup::make(__('nova-permission-tool::permissions.roles'), 'roles'),
 
             MorphToMany::make($userResource::label(), 'users', $userResource)
                 ->searchable()

--- a/src/Permission.php
+++ b/src/Permission.php
@@ -110,7 +110,7 @@ class Permission extends Resource
             DateTime::make(__('nova-permission-tool::permissions.created_at'), 'created_at')->exceptOnForms(),
             DateTime::make(__('nova-permission-tool::permissions.updated_at'), 'updated_at')->exceptOnForms(),
 
-            RoleBooleanGroup::make('Roles'),
+            RoleBooleanGroup::make(__('nova-permission-tool::permissions.roles'),'roles'),
 
             MorphToMany::make($userResource::label(), 'users', $userResource)
                 ->searchable()

--- a/src/Role.php
+++ b/src/Role.php
@@ -104,7 +104,7 @@ class Role extends Resource
             DateTime::make(__('nova-permission-tool::roles.created_at'), 'created_at')->exceptOnForms(),
             DateTime::make(__('nova-permission-tool::roles.updated_at'), 'updated_at')->exceptOnForms(),
 
-            PermissionBooleanGroup::make(__('nova-permission-tool::roles.permissions'),'permissions'),
+            PermissionBooleanGroup::make(__('nova-permission-tool::roles.permissions'), 'permissions'),
 
             MorphToMany::make($userResource::label(), 'users', $userResource)
                 ->searchable()

--- a/src/Role.php
+++ b/src/Role.php
@@ -104,7 +104,7 @@ class Role extends Resource
             DateTime::make(__('nova-permission-tool::roles.created_at'), 'created_at')->exceptOnForms(),
             DateTime::make(__('nova-permission-tool::roles.updated_at'), 'updated_at')->exceptOnForms(),
 
-            PermissionBooleanGroup::make('Permissions'),
+            PermissionBooleanGroup::make(__('nova-permission-tool::roles.permissions'),'permissions'),
 
             MorphToMany::make($userResource::label(), 'users', $userResource)
                 ->searchable()


### PR DESCRIPTION
Hi, just noticed some labels were not getting translated.

![image](https://user-images.githubusercontent.com/694313/79878235-d2aa1280-83b2-11ea-89fc-13cfa490fff1.png)

Thank you for this great project!