### PR TITLE
Limit role and permission visibility based on policies.

### DIFF
--- a/src/PermissionBooleanGroup.php
+++ b/src/PermissionBooleanGroup.php
@@ -8,6 +8,7 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\Models\Permission as PermissionModel;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
+use Auth;
 
 class PermissionBooleanGroup extends BooleanGroup
 {
@@ -25,7 +26,10 @@ class PermissionBooleanGroup extends BooleanGroup
 
         $permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
 
-        $options = $permissionClass::get()->pluck($labelAttribute ?? 'name', 'name')->toArray();
+        $options = $permissionClass::get()->pluck($labelAttribute ?? 'name', 'name')->map(function ($permission) {
+            if(Auth::user()->can('view', PermissionModel::where('name', $permission)->first()))
+                return $permission;
+        })->whereNotNull()->toArray();
 
         $this->options($options);
     }

--- a/src/PermissionBooleanGroup.php
+++ b/src/PermissionBooleanGroup.php
@@ -2,13 +2,13 @@
 
 namespace Vyuldashev\NovaPermission;
 
+use Auth;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Fields\BooleanGroup;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\Models\Permission as PermissionModel;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
-use Auth;
 
 class PermissionBooleanGroup extends BooleanGroup
 {
@@ -26,10 +26,9 @@ class PermissionBooleanGroup extends BooleanGroup
 
         $permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
 
-        $options = $permissionClass::get()->pluck($labelAttribute ?? 'name', 'name')->map(function ($permission) {
-            if(Auth::user()->can('view', PermissionModel::where('name', $permission)->first()))
-                return $permission;
-        })->whereNotNull()->toArray();
+        $options = $permissionClass::get()->pluck($labelAttribute ?? 'name', 'name')->filter(function ($permission) {
+                return Auth::user()->can('view', PermissionModel::where('name', $permission)->first());
+        })->toArray();
 
         $this->options($options);
     }

--- a/src/PermissionBooleanGroup.php
+++ b/src/PermissionBooleanGroup.php
@@ -27,7 +27,7 @@ class PermissionBooleanGroup extends BooleanGroup
         $permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
 
         $options = $permissionClass::get()->pluck($labelAttribute ?? 'name', 'name')->filter(function ($permission) {
-                return Auth::user()->can('view', PermissionModel::where('name', $permission)->first());
+            return Auth::user()->can('view', PermissionModel::where('name', $permission)->first());
         })->toArray();
 
         $this->options($options);

--- a/src/RoleBooleanGroup.php
+++ b/src/RoleBooleanGroup.php
@@ -2,13 +2,13 @@
 
 namespace Vyuldashev\NovaPermission;
 
+use Auth;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Fields\BooleanGroup;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\Models\Role as RoleModel;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
-use Auth;
 
 class RoleBooleanGroup extends BooleanGroup
 {
@@ -26,10 +26,9 @@ class RoleBooleanGroup extends BooleanGroup
 
         $roleClass = app(PermissionRegistrar::class)->getRoleClass();
 
-        $options = $roleClass::get()->pluck($labelAttribute ?? 'name', 'name')->map(function ($role) {
-            if(Auth::user()->can('view', RoleModel::where('name', $role)->first()))
-                return $role;
-        })->whereNotNull()->toArray();
+        $options = $roleClass::get()->pluck($labelAttribute ?? 'name', 'name')->filter(function ($role) {
+            return Auth::user()->can('view', RoleModel::where('name', $role)->first());
+        })->toArray();
 
         $this->options($options);
     }

--- a/src/RoleBooleanGroup.php
+++ b/src/RoleBooleanGroup.php
@@ -8,6 +8,7 @@ use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\Models\Role as RoleModel;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
+use Auth;
 
 class RoleBooleanGroup extends BooleanGroup
 {
@@ -25,7 +26,10 @@ class RoleBooleanGroup extends BooleanGroup
 
         $roleClass = app(PermissionRegistrar::class)->getRoleClass();
 
-        $options = $roleClass::get()->pluck($labelAttribute ?? 'name', 'name')->toArray();
+        $options = $roleClass::get()->pluck($labelAttribute ?? 'name', 'name')->map(function ($role) {
+            if(Auth::user()->can('view', RoleModel::where('name', $role)->first()))
+                return $role;
+        })->whereNotNull()->toArray();
 
         $this->options($options);
     }

--- a/src/RoleSelect.php
+++ b/src/RoleSelect.php
@@ -5,8 +5,10 @@ namespace Vyuldashev\NovaPermission;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Http\Requests\NovaRequest;
+use Spatie\Permission\Models\Role as RoleModel;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
+use Auth;
 
 class RoleSelect extends Select
 {
@@ -22,7 +24,10 @@ class RoleSelect extends Select
 
         $roleClass = app(PermissionRegistrar::class)->getRoleClass();
 
-        $options = $roleClass::get()->pluck($labelAttribute ?? 'name', 'name')->toArray();
+        $options = $roleClass::get()->pluck($labelAttribute ?? 'name', 'name')->map(function ($role) {
+            if(Auth::user()->can('view', RoleModel::where('name', $role)->first()))
+                return $role;
+        })->whereNotNull()->toArray();
 
         $this->options($options);
     }

--- a/src/RoleSelect.php
+++ b/src/RoleSelect.php
@@ -2,13 +2,13 @@
 
 namespace Vyuldashev\NovaPermission;
 
+use Auth;
 use Illuminate\Support\Collection;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Http\Requests\NovaRequest;
 use Spatie\Permission\Models\Role as RoleModel;
 use Spatie\Permission\PermissionRegistrar;
 use Spatie\Permission\Traits\HasPermissions;
-use Auth;
 
 class RoleSelect extends Select
 {
@@ -24,10 +24,9 @@ class RoleSelect extends Select
 
         $roleClass = app(PermissionRegistrar::class)->getRoleClass();
 
-        $options = $roleClass::get()->pluck($labelAttribute ?? 'name', 'name')->map(function ($role) {
-            if(Auth::user()->can('view', RoleModel::where('name', $role)->first()))
-                return $role;
-        })->whereNotNull()->toArray();
+        $options = $roleClass::get()->pluck($labelAttribute ?? 'name', 'name')->filter(function ($role) {
+            return Auth::user()->can('view', RoleModel::where('name', $role)->first());
+        })->toArray();
 
         $this->options($options);
     }


### PR DESCRIPTION
Occasionally I need to limit what roles and permissions are visible.

With the MorphToMany option this can be done with a simple relatableQuery:
```
public static function relatableRoles(NovaRequest $request, $query)
{
    return $query->...
}
```

But not so with RoleBooleanGroup, PermissionBooleanGroup, or RoleSelect. So I came up with this solution based upon whether the User has permission to view the role or permission in the respective policy. 

This might address #117. 