### PR TITLE
Various fixes

### DIFF
--- a/resources/lang/ru/permissions.php
+++ b/resources/lang/ru/permissions.php
@@ -6,4 +6,5 @@ return [
     'guard_name' => 'Имя Guard',
     'created_at' => 'Создан',
     'updated_at' => 'Обновлен',
+    'roles' => 'Роли',
 ];

--- a/resources/lang/ru/roles.php
+++ b/resources/lang/ru/roles.php
@@ -5,4 +5,5 @@ return [
     'guard_name' => 'Имя Guard',
     'created_at' => 'Создан',
     'updated_at' => 'Обновлен',
+    'permissions' => 'Права',
 ];

--- a/src/NovaPermissionTool.php
+++ b/src/NovaPermissionTool.php
@@ -26,6 +26,9 @@ class NovaPermissionTool extends Tool
             $this->permissionResource,
         ]);
 
+        ($this->permissionResource)::$model = config('permission.models.permission');
+        ($this->roleResource)::$model = config('permission.models.role');
+
         Gate::policy(config('permission.models.permission'), $this->permissionPolicy);
         Gate::policy(config('permission.models.role'), $this->rolePolicy);
     }

--- a/src/Permission.php
+++ b/src/Permission.php
@@ -21,7 +21,7 @@ class Permission extends Resource
      *
      * @var string
      */
-    public static $model = \Spatie\Permission\Models\Permission::class;
+    public static $model = '';
 
     /**
      * The single value that should be used to represent the resource when being displayed.

--- a/src/PermissionBooleanGroup.php
+++ b/src/PermissionBooleanGroup.php
@@ -16,10 +16,12 @@ class PermissionBooleanGroup extends BooleanGroup
         parent::__construct(
             $name,
             $attribute,
-            $resolveCallback ?? static function (Collection $permissions) {
-                return $permissions->mapWithKeys(function (PermissionModel $permission) {
-                    return [$permission->name => true];
-                });
+            $resolveCallback ?? static function (?Collection $permissions) {
+                if ($permissions) {
+                    return $permissions->mapWithKeys(function (PermissionModel $permission) {
+                        return [$permission->name => true];
+                    });
+                }
             }
         );
 

--- a/src/Role.php
+++ b/src/Role.php
@@ -21,7 +21,7 @@ class Role extends Resource
      *
      * @var string
      */
-    public static $model = \Spatie\Permission\Models\Role::class;
+    public static $model = '';
 
     /**
      * The single value that should be used to represent the resource when being displayed.

--- a/src/RoleBooleanGroup.php
+++ b/src/RoleBooleanGroup.php
@@ -16,10 +16,12 @@ class RoleBooleanGroup extends BooleanGroup
         parent::__construct(
             $name,
             $attribute,
-            $resolveCallback ?? static function (Collection $permissions) {
-                return $permissions->mapWithKeys(function (RoleModel $role) {
-                    return [$role->name => true];
-                });
+            $resolveCallback ?? static function (?Collection $permissions) {
+                if ($permissions) {
+                    return $permissions->mapWithKeys(function (RoleModel $role) {
+                        return [$role->name => true];
+                    });
+                }
             }
         );
 


### PR DESCRIPTION
* Permission resource references 'nova-permission-tool::permissions.roles' lang key, but key is missed. Same for the Role resource with 'nova-permission-tool::roles.permissions' key. Added missed keys to 'ru' translation.

* Default $resolveCallback function in PermissionBooleanGroup class failing with null argument error. Same for RoleBooleanGroup class. Added nullable type hint and check for value before mapping.

* Custom policies does't work if model classes are changed in 'config/permission.php' file because $model property of resources references Spatie models. Added dynamically setting of models in 'NovaPermissionTool.php'.

Please accept this PR.