### PR TITLE
Translate the permission according to the display_name

### DIFF
--- a/src/PermissionBooleanGroup.php
+++ b/src/PermissionBooleanGroup.php
@@ -25,8 +25,13 @@ class PermissionBooleanGroup extends BooleanGroup
 
         $permissionClass = app(PermissionRegistrar::class)->getPermissionClass();
 
-        $options = $permissionClass::get()->pluck($labelAttribute ?? 'name', 'name')->toArray();
+ $options = $permissionClass::get()->pluck($labelAttribute ?? 'name', 'name')->mapWithKeys(function ($permissionName)
+        {
+            $translation = ! empty(__('nova-permission-tool::permissions.display_names.'.$permissionName)) ? __('nova-permission-tool::permissions.display_names.'.$permissionName) : $permissionName;
 
+            return [$permissionName => $translation];
+        })->toArray(); 
+        
         $this->options($options);
     }
 


### PR DESCRIPTION
When translation key `display_names` has been set in the `resources\lang\vendor\nova-permission-tool\en\permissions.php` it show the translation only in the Permission index page. This Pr aim to show the translation also when adding/editing/showing Role's permission. This is more consistant with https://github.com/vyuldashev/nova-permission/issues/21#issuecomment-416731516