### PR TITLE
Adding PHP 7.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.4|^8.0",
         "spatie/laravel-permission": "^3.0|^4.0"
     },
     "autoload": {

--- a/src/AttachToRole.php
+++ b/src/AttachToRole.php
@@ -17,8 +17,8 @@ class AttachToRole extends Action
     /**
      * Perform the action on the given models.
      *
-     * @param  \Laravel\Nova\Fields\ActionFields  $fields
-     * @param  \Illuminate\Support\Collection  $models
+     * @param ActionFields $fields
+     * @param Collection $models
      * @return mixed
      */
     public function handle(ActionFields $fields, Collection $models)

--- a/src/ForgetCachedPermissions.php
+++ b/src/ForgetCachedPermissions.php
@@ -7,14 +7,13 @@ namespace Vyuldashev\NovaPermission;
 use Laravel\Nova\Nova;
 use Spatie\Permission\PermissionRegistrar;
 use Illuminate\Support\Str;
-use Illuminate\Http\Request;
 
 class ForgetCachedPermissions
 {
     /**
      * Handle the incoming request.
      *
-     * @param Request|mixed $request
+     * @param \Illuminate\Http\Request|mixed $request
      * @param \Closure $next
      *
      * @return mixed

--- a/src/ForgetCachedPermissions.php
+++ b/src/ForgetCachedPermissions.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Vyuldashev\NovaPermission;
 
-use Illuminate\Http\Request;
 use Laravel\Nova\Nova;
 use Spatie\Permission\PermissionRegistrar;
 use Illuminate\Support\Str;
+use Illuminate\Http\Request;
 
 class ForgetCachedPermissions
 {

--- a/src/ForgetCachedPermissions.php
+++ b/src/ForgetCachedPermissions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vyuldashev\NovaPermission;
 
+use Illuminate\Http\Request;
 use Laravel\Nova\Nova;
 use Spatie\Permission\PermissionRegistrar;
 use Illuminate\Support\Str;
@@ -13,7 +14,7 @@ class ForgetCachedPermissions
     /**
      * Handle the incoming request.
      *
-     * @param \Illuminate\Http\Request|mixed $request
+     * @param Request|mixed $request
      * @param \Closure $next
      *
      * @return mixed

--- a/src/NovaPermissionTool.php
+++ b/src/NovaPermissionTool.php
@@ -8,11 +8,11 @@ use Laravel\Nova\Tool;
 
 class NovaPermissionTool extends Tool
 {
-    public $roleResource = Role::class;
-    public $permissionResource = Permission::class;
+    public string $roleResource = Role::class;
+    public string $permissionResource = Permission::class;
 
-    public $rolePolicy = RolePolicy::class;
-    public $permissionPolicy = PermissionPolicy::class;
+    public string $rolePolicy = RolePolicy::class;
+    public string $permissionPolicy = PermissionPolicy::class;
 
     /**
      * Perform any tasks that need to happen when the tool is booted.
@@ -30,21 +30,21 @@ class NovaPermissionTool extends Tool
         Gate::policy(config('permission.models.role'), $this->rolePolicy);
     }
 
-    public function roleResource(string $roleResource)
+    public function roleResource(string $roleResource): NovaPermissionTool
     {
         $this->roleResource = $roleResource;
 
         return $this;
     }
 
-    public function permissionResource(string $permissionResource)
+    public function permissionResource(string $permissionResource): NovaPermissionTool
     {
         $this->permissionResource = $permissionResource;
 
         return $this;
     }
 
-    public function rolePolicy(string $rolePolicy)
+    public function rolePolicy(string $rolePolicy): NovaPermissionTool
     {
         $this->rolePolicy = $rolePolicy;
 

--- a/src/Permission.php
+++ b/src/Permission.php
@@ -21,21 +21,21 @@ class Permission extends Resource
      *
      * @var string
      */
-    public static $model = \Spatie\Permission\Models\Permission::class;
+    public static string $model = \Spatie\Permission\Models\Permission::class;
 
     /**
      * The single value that should be used to represent the resource when being displayed.
      *
      * @var string
      */
-    public static $title = 'name';
+    public static string $title = 'name';
 
     /**
      * The columns that should be searched.
      *
      * @var array
      */
-    public static $search = [
+    public static array $search = [
         'name',
     ];
 
@@ -49,7 +49,7 @@ class Permission extends Resource
      *
      * @return string
      */
-    public static function group()
+    public static function group(): string
     {
         return __('nova-permission-tool::navigation.sidebar-label');
     }
@@ -60,7 +60,7 @@ class Permission extends Resource
      * @param Request $request
      * @return bool
      */
-    public static function availableForNavigation(Request $request)
+    public static function availableForNavigation(Request $request): bool
     {
         return Gate::allows('viewAny', app(PermissionRegistrar::class)->getPermissionClass());
     }
@@ -81,7 +81,7 @@ class Permission extends Resource
      * @param Request $request
      * @return array
      */
-    public function fields(Request $request)
+    public function fields(Request $request): array
     {
         $guardOptions = collect(config('auth.guards'))->mapWithKeys(function ($value, $key) {
             return [$key => $key];
@@ -124,7 +124,7 @@ class Permission extends Resource
      * @param Request $request
      * @return array
      */
-    public function cards(Request $request)
+    public function cards(Request $request): array
     {
         return [];
     }
@@ -135,7 +135,7 @@ class Permission extends Resource
      * @param Request $request
      * @return array
      */
-    public function filters(Request $request)
+    public function filters(Request $request): array
     {
         return [];
     }
@@ -146,7 +146,7 @@ class Permission extends Resource
      * @param Request $request
      * @return array
      */
-    public function lenses(Request $request)
+    public function lenses(Request $request): array
     {
         return [];
     }
@@ -157,7 +157,7 @@ class Permission extends Resource
      * @param Request $request
      * @return array
      */
-    public function actions(Request $request)
+    public function actions(Request $request): array
     {
         return [
             new AttachToRole,

--- a/src/Role.php
+++ b/src/Role.php
@@ -21,21 +21,21 @@ class Role extends Resource
      *
      * @var string
      */
-    public static $model = \Spatie\Permission\Models\Role::class;
+    public static string $model = \Spatie\Permission\Models\Role::class;
 
     /**
      * The single value that should be used to represent the resource when being displayed.
      *
      * @var string
      */
-    public static $title = 'name';
+    public static string $title = 'name';
 
     /**
      * The columns that should be searched.
      *
      * @var array
      */
-    public static $search = [
+    public static array $search = [
         'name',
     ];
 

--- a/src/RoleBooleanGroup.php
+++ b/src/RoleBooleanGroup.php
@@ -36,7 +36,7 @@ class RoleBooleanGroup extends BooleanGroup
      * @param HasPermissions $model
      * @param string $attribute
      */
-    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
+    protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, HasPermissions $model, string $attribute)
     {
         if (! $request->exists($requestAttribute)) {
             return;

--- a/src/RoleSelect.php
+++ b/src/RoleSelect.php
@@ -33,7 +33,7 @@ class RoleSelect extends Select
      * @param HasPermissions $model
      * @param string $attribute
      */
-    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
+    protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, HasPermissions $model, string $attribute)
     {
         if (! $request->exists($requestAttribute)) {
             return;
@@ -53,7 +53,7 @@ class RoleSelect extends Select
      *
      * @return $this
      */
-    public function displayUsingLabels()
+    public function displayUsingLabels(): RoleSelect
     {
         return $this->displayUsing(function ($value) {
             return collect($this->meta['options'])


### PR DESCRIPTION
If the project is running on PHP 7.4 appears errors related with variables not types
```sh
Type of Vyuldashev\NovaPermission\Role::$title must be string (as in class Laravel\Nova\Resource)
```

This PR fix the issue in PHP 7.4