### PR TITLE
Fixes typehint errors potentially caused by latest changes

### DIFF
--- a/src/Permission.php
+++ b/src/Permission.php
@@ -28,14 +28,14 @@ class Permission extends Resource
      *
      * @var string
      */
-    public static string $title = 'name';
+    public static $title = 'name';
 
     /**
      * The columns that should be searched.
      *
      * @var array
      */
-    public static array $search = [
+    public static $search = [
         'name',
     ];
 

--- a/src/Role.php
+++ b/src/Role.php
@@ -28,14 +28,14 @@ class Role extends Resource
      *
      * @var string
      */
-    public static string $title = 'name';
+    public static $title = 'name';
 
     /**
      * The columns that should be searched.
      *
      * @var array
      */
-    public static array $search = [
+    public static $search = [
         'name',
     ];
 

--- a/src/RoleBooleanGroup.php
+++ b/src/RoleBooleanGroup.php
@@ -36,7 +36,7 @@ class RoleBooleanGroup extends BooleanGroup
      * @param HasPermissions $model
      * @param string $attribute
      */
-    protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, HasPermissions $model, string $attribute)
+    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
         if (! $request->exists($requestAttribute)) {
             return;


### PR DESCRIPTION
Role.php and Permission.php extends Laravel\Nova\Resource.php

#161 adds typehints to properties and some methods that are not typehinted in the classes that are extended in Laravel Nova.

public properties `$title` and `$search` are not typehinted in Resource.php.
But are typehinted as string and array in Role and Permission which causes breakage as for example Nova Resource `$title` might not always be a string.

Unless I'm completely off, the previous commits should be corrected as they are not typehinted in their parent classes?

I'm now getting the following error on a fresh installation on both PHP 8.0 and PHP 7.4
```
Symfony\Component\ErrorHandler\Error\FatalError: Type of Vyuldashev\NovaPermission\Role::$title must not be defined (as in class Laravel\Nova\Resource) in file /vendor/vyuldashev/nova-permission/src/Role.php on line 0
```

Or am I missing something here?