### PR TITLE
Fix incompatible types

### DIFF
--- a/src/Permission.php
+++ b/src/Permission.php
@@ -21,21 +21,21 @@ class Permission extends Resource
      *
      * @var string
      */
-    public static string $model = \Spatie\Permission\Models\Permission::class;
+    public static $model = \Spatie\Permission\Models\Permission::class;
 
     /**
      * The single value that should be used to represent the resource when being displayed.
      *
      * @var string
      */
-    public static string $title = 'name';
+    public static $title = 'name';
 
     /**
      * The columns that should be searched.
      *
      * @var array
      */
-    public static array $search = [
+    public static $search = [
         'name',
     ];
 

--- a/src/Role.php
+++ b/src/Role.php
@@ -21,21 +21,21 @@ class Role extends Resource
      *
      * @var string
      */
-    public static string $model = \Spatie\Permission\Models\Role::class;
+    public static $model = \Spatie\Permission\Models\Role::class;
 
     /**
      * The single value that should be used to represent the resource when being displayed.
      *
      * @var string
      */
-    public static string $title = 'name';
+    public static $title = 'name';
 
     /**
      * The columns that should be searched.
      *
      * @var array
      */
-    public static array $search = [
+    public static $search = [
         'name',
     ];
 

--- a/src/RoleBooleanGroup.php
+++ b/src/RoleBooleanGroup.php
@@ -36,7 +36,7 @@ class RoleBooleanGroup extends BooleanGroup
      * @param HasPermissions $model
      * @param string $attribute
      */
-    protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, HasPermissions $model, string $attribute)
+    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
         if (! $request->exists($requestAttribute)) {
             return;

--- a/src/RoleSelect.php
+++ b/src/RoleSelect.php
@@ -33,7 +33,7 @@ class RoleSelect extends Select
      * @param HasPermissions $model
      * @param string $attribute
      */
-    protected function fillAttributeFromRequest(NovaRequest $request, string $requestAttribute, HasPermissions $model, string $attribute)
+    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
     {
         if (! $request->exists($requestAttribute)) {
             return;


### PR DESCRIPTION
Remove type hints for fields as those are not compatible with Laravel\Nova\Resource

Remove type hints for RoleBooleanGroup::fillAttributeFromRequest as this isn't compatible with the base class

Fixes #163