### PR TITLE
fix parameter namespace error thrown

### DIFF
--- a/src/ForgetCachedPermissions.php
+++ b/src/ForgetCachedPermissions.php
@@ -5,6 +5,8 @@ namespace Vyuldashev\NovaPermission;
 use Laravel\Nova\Nova;
 use Spatie\Permission\PermissionRegistrar;
 use Illuminate\Support\Str;
+use Illuminate\Http\Request;
+use Closure;
 
 class ForgetCachedPermissions
 {


### PR DESCRIPTION
PHP: 8.1.8
Laravel: 9.21.3

Error:
Vyuldashev\NovaPermission\ForgetCachedPermissions::handle(): Argument #1 ($request) must be of type Vyuldashev\NovaPermission\Request, Illuminate\Http\Request given, called in /raptor/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php on line 180