### PR TITLE
Cast $role->name to string in RoleBooleanGroup

### DIFF
--- a/src/RoleBooleanGroup.php
+++ b/src/RoleBooleanGroup.php
@@ -18,7 +18,7 @@ class RoleBooleanGroup extends BooleanGroup
             $attribute,
             $resolveCallback ?? static function (Collection $permissions) {
                 return $permissions->mapWithKeys(function (RoleModel $role) {
-                    return [$role->name => true];
+                    return [(string) $role->name => true];
                 });
             }
         );


### PR DESCRIPTION
Getting the following error due to Spatie switching some value to enums.

```bash
exception: "TypeError"
file: "/var/www/html/vendor/vyuldashev/nova-permission/src/RoleBooleanGroup.php"
line: 21 
message: "Illegal offset type"
```

Currently enums can't be used as array keys. See: https://stitcher.io/blog/php-enums#enums-as-array-keys.